### PR TITLE
Fix issue ant-antlibs-common submodule not found

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "common"]
 	path = common
-	url = https://git-wip-us.apache.org/repos/asf/ant-antlibs-common.git
+	url = https://github.com/apache/ant-antlibs-common.git


### PR DESCRIPTION
Hello, today during installation of this project I have faced an issue like that:

+ git submodule init
Submodule 'common' (https://git-wip-us.apache.org/repos/asf/ant-antlibs-common.git) registered for path 'common'
+ git submodule update
Cloning into '/tmp/props/common'...
fatal: repository 'https://git-wip-us.apache.org/repos/asf/ant-antlibs-common.git/' not found
fatal: clone of 'https://git-wip-us.apache.org/repos/asf/ant-antlibs-common.git' into submodule path '/tmp/props/common' failed
Failed to clone 'common'. Retry scheduled